### PR TITLE
Add start and end dates to scrap news

### DIFF
--- a/r2d2/spiders/news_google_finance.py
+++ b/r2d2/spiders/news_google_finance.py
@@ -10,10 +10,19 @@ class NewsGoogleFinanceSpider(scrapy.Spider):
     name = "news_google_finance"
     symbols = ['NASDAQ:PYPL', 'NYSE:SQ', 'NYSE:V', 'NYSE:MA']
 
+    startdate1 = ''
+    enddate1 = ''
+
+    def __init__(self, startdate='', enddate='',*args, **kwargs):
+        global startdate1
+        global enddate1
+        startdate1 = startdate
+        enddate1 = enddate
+
     def start_requests(self):
     	for symbol in self.symbols:
     		#stock = getQuotes(symbol)
-    		news = getNews(symbol)
+    		news = getNews(symbol,startdate1,enddate1)
     		for article in news:
     			if "hour" in article['d']:
     				yield scrapy.Request(article['u'], self.parse)


### PR DESCRIPTION
Usage: scrapy crawl news_google_finance -a startdate=2016-4-23 -a enddate=2016-4-24

startdate and enddate are optional
